### PR TITLE
Beautify flats index page with Airbnb-style cards and add new flat bu…

### DIFF
--- a/app/assets/stylesheets/components/_flats.scss
+++ b/app/assets/stylesheets/components/_flats.scss
@@ -1,0 +1,47 @@
+.page-title {
+  font-weight: 700;
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.btn-add-flat {
+  background-color: #FF385C;
+  color: white !important;
+  font-weight: 600;
+  border-radius: 8px;
+  padding: 0.6rem 1.2rem;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  margin-top: 0.5rem;
+  text-decoration: none;
+  display: inline-block;
+
+  &:hover {
+    background-color: #e03150;
+    color: white !important;
+    text-decoration: none;
+  }
+}
+
+.flat-card {
+  border: none;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+
+  &:hover {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+}
+
+.img-hover-zoom {
+  transition: transform 0.3s ease;
+  object-fit: cover;
+  width: 100%;
+  height: 250px;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -5,3 +5,4 @@
 @import "navbar";
 @import "footer";
 @import "auth";
+@import "flats";

--- a/app/views/flats/index.html.erb
+++ b/app/views/flats/index.html.erb
@@ -1,9 +1,25 @@
-<h1>Homepage</h1>
-<div>
-    <% @flats.each do |flat| %>
-      <p><%= flat.title %></p>
-      <p><%= flat.description %></p>
-      <p><%= flat.location %></p>
-      <p><%= flat.price_per_night %></p>
-    <% end %>
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="page-title">Explore Flats</h1>
+  <%= link_to "+ Add New Flat", new_flat_path, class: "btn-add-flat" %>
+</div>
+
+<div class="row">
+  <% @flats.each do |flat| %>
+    <div class="col-md-4 mb-4">
+      <div class="card flat-card h-100 shadow-sm rounded">
+        <% if flat.photos.attached? %>
+          <%= image_tag flat.photos.first.variant(resize_to_fill: [400, 250]), class: "card-img-top img-hover-zoom" %>
+        <% else %>
+          <%= image_tag "https://source.unsplash.com/400x250/?apartment", class: "card-img-top img-hover-zoom" %>
+        <% end %>
+
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title"><%= flat.title %></h5>
+          <p class="card-text text-muted mb-2"><%= flat.location %></p>
+          <p class="card-text fw-bold mb-3">£<%= flat.price_per_night %> per night</p>
+          <%= link_to 'View Flat', flat_path(flat), class: "btn btn-primary mt-auto" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.1].define(version: 2025_06_03_151602) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "bookings", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "flat_id", null: false
-    t.datetime "start_date"
-    t.datetime "end_date"
-    t.string "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["flat_id"], name: "index_bookings_on_flat_id"
-    t.index ["user_id"], name: "index_bookings_on_user_id"
-=======
 ActiveRecord::Schema[7.1].define(version: 2025_06_03_151641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +42,18 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_03_151641) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "bookings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "flat_id", null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["flat_id"], name: "index_bookings_on_flat_id"
+    t.index ["user_id"], name: "index_bookings_on_user_id"
+  end
+
   create_table "flats", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -82,10 +78,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_03_151641) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-
-  add_foreign_key "bookings", "flats"
-  add_foreign_key "bookings", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "bookings", "flats"
+  add_foreign_key "bookings", "users"
   add_foreign_key "flats", "users"
 end


### PR DESCRIPTION
The .flat-card cards have subtle shadows and round edges.

Images zoom in gently on hover.

The "Add New Flat" button is bright red and stands out.

Text styles for title, location, and price are clear and clean.

Cards are arranged nicely in a responsive 3-column grid.

